### PR TITLE
feat: 使用Github Actions自动构建和发布

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,35 @@
+name: Build Debug APK
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-debug-apk:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-arm64-v8a-debug.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,13 @@ name: Release new version
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-and-package:
     name: Build Release APK
     runs-on: ubuntu-latest
-    outputs:
-      apk_path: ${{ steps.build_release_apk.outputs.apk_path }}
-      apk_name: ${{ steps.build_release_apk.outputs.apk_name }}
 
     steps:
       - name: Checkout code
@@ -27,36 +25,35 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Decode Keystore
-        id: decode_keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-          KEYSTORE_FILE_PATH: app/release.jks
-        run: |
-          echo "Decoding Keystore..."
-          echo $KEYSTORE_BASE64 | base64 --decode > $KEYSTORE_FILE_PATH
-          echo "Keystore decoded to $KEYSTORE_FILE_PATH"
+      - name: Build Unsigned Release APK
+        run: ./gradlew assembleRelease
 
-      - name: Build Release APK
-        id: build_release_apk
-        env:
-          KEYSTORE_FILE: release.jks
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      - name: Get Build Tool Version & Rename
+        shell: bash
         run: |
-          ./gradlew assembleRelease
-          APK_FILE="app/build/outputs/apk/release/app-arm64-v8a-release.apk"
-          echo "apk_path=${APK_FILE}" >> $GITHUB_OUTPUT
-          echo "apk_name=$(basename ${APK_FILE})" >> $GITHUB_OUTPUT
-          echo "Found APK: ${APK_FILE}"
+          BUILD_TOOL_VERSION=$(ls /usr/local/lib/android/sdk/build-tools/ | tail -n 1)
+          echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
+          mv app/build/outputs/apk/release/app-arm64-v8a-release-unsigned.apk app/build/outputs/apk/release/app-arm64-v8a-release.apk
+
+      - name: Sign APK
+        id: sign-apk
+        uses: tiann/zipalign-sign-android-release@v1.1.4
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          zipAlign: true
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-release-apk
           path: |
-            ${{ steps.build_release_apk.outputs.apk_path }}
+            ${{ steps.sign-apk.outputs.signedReleaseFile }}
 
   create-release:
     name: Create Release
@@ -93,7 +90,7 @@ jobs:
           VERSION_NUMBER=$(echo "$TAG_NAME" | sed 's/^v//')
           echo "version_number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION_NUMBER from tag: $TAG_NAME"
-          echo "original_apk_path=./release-artifacts/app-arm64-v8a-release.apk" >> $GITHUB_OUTPUT
+          echo "original_apk_path=./release-artifacts/app-arm64-v8a-release-signed.apk" >> $GITHUB_OUTPUT
           
       - name: Create Release
         id: create_release_step

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release new version
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  build-and-package:
+    name: Build Release APK
+    runs-on: ubuntu-latest
+    outputs:
+      apk_path: ${{ steps.build_release_apk.outputs.apk_path }}
+      apk_name: ${{ steps.build_release_apk.outputs.apk_name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Decode Keystore
+        id: decode_keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          KEYSTORE_FILE_PATH: app/release.jks
+        run: |
+          echo "Decoding Keystore..."
+          echo $KEYSTORE_BASE64 | base64 --decode > $KEYSTORE_FILE_PATH
+          echo "Keystore decoded to $KEYSTORE_FILE_PATH"
+
+      - name: Build Release APK
+        id: build_release_apk
+        env:
+          KEYSTORE_FILE: release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease
+          APK_FILE="app/build/outputs/apk/release/app-arm64-v8a-release.apk"
+          echo "apk_path=${APK_FILE}" >> $GITHUB_OUTPUT
+          echo "apk_name=$(basename ${APK_FILE})" >> $GITHUB_OUTPUT
+          echo "Found APK: ${APK_FILE}"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: |
+            ${{ steps.build_release_apk.outputs.apk_path }}
+
+  create-release:
+    name: Create Release
+    needs: build-and-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+          
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release-apk
+          path: ./release-artifacts
+          
+      - name: Get Commit Message for Release Notes
+        id: get_commit_message
+        run: |
+          COMMIT_MESSAGE_BODY=$(git log -1 --pretty=%b ${{ github.sha }})
+          if [ -z "$COMMIT_MESSAGE_BODY" ]; then
+            COMMIT_MESSAGE_BODY="该版本的详细更新日志请参见相关的 commit 历史。"
+          fi
+          echo "release_notes_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMIT_MESSAGE_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        shell: bash
+        
+      - name: Extract Version from Tag
+        id: extract_version
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          VERSION_NUMBER=$(echo "$TAG_NAME" | sed 's/^v//')
+          echo "version_number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION_NUMBER from tag: $TAG_NAME"
+          echo "original_apk_path=./release-artifacts/app-arm64-v8a-release.apk" >> $GITHUB_OUTPUT
+          
+      - name: Create Release
+        id: create_release_step
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: 交大自由行${{ github.ref_name }}
+          body: ${{ steps.get_commit_message.outputs.release_notes_body }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          
+      - name: Upload Release APK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release_step.outputs.upload_url }}
+          asset_path: ${{ steps.extract_version.outputs.original_apk_path }}
+          asset_name: BJTUSelfSevice-${{ steps.extract_version.outputs.version_number }}_arm64-v8a.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,5 +111,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release_step.outputs.upload_url }}
           asset_path: ${{ steps.extract_version.outputs.original_apk_path }}
-          asset_name: BJTUSelfSevice-${{ steps.extract_version.outputs.version_number }}_arm64-v8a.apk
+          asset_name: BJTUSelfService-${{ steps.extract_version.outputs.version_number }}_arm64-v8a.apk
           asset_content_type: application/vnd.android.package-archive

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,30 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    val keystoreFileFromEnv = System.getenv("KEYSTORE_FILE")
+    val keystorePasswordFromEnv = System.getenv("KEYSTORE_PASSWORD")
+    val keyAliasFromEnv = System.getenv("KEY_ALIAS")
+    val keyPasswordFromEnv = System.getenv("KEY_PASSWORD")
+
+    signingConfigs {
+        create("release") {
+            if (keystoreFileFromEnv != null && keystoreFileFromEnv.isNotEmpty() &&
+                keystorePasswordFromEnv != null && keystorePasswordFromEnv.isNotEmpty() &&
+                keyAliasFromEnv != null && keyAliasFromEnv.isNotEmpty() &&
+                keyPasswordFromEnv != null && keyPasswordFromEnv.isNotEmpty()) {
+                storeFile = file(keystoreFileFromEnv)
+                storePassword = keystorePasswordFromEnv
+                keyAlias = keyAliasFromEnv
+                keyPassword = keyPasswordFromEnv
+            } else {
+                println("Warning: Release signing information not fully provided via environment variables. The release build might not be signed or might fail.")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,30 +21,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    val keystoreFileFromEnv = System.getenv("KEYSTORE_FILE")
-    val keystorePasswordFromEnv = System.getenv("KEYSTORE_PASSWORD")
-    val keyAliasFromEnv = System.getenv("KEY_ALIAS")
-    val keyPasswordFromEnv = System.getenv("KEY_PASSWORD")
-
-    signingConfigs {
-        create("release") {
-            if (keystoreFileFromEnv != null && keystoreFileFromEnv.isNotEmpty() &&
-                keystorePasswordFromEnv != null && keystorePasswordFromEnv.isNotEmpty() &&
-                keyAliasFromEnv != null && keyAliasFromEnv.isNotEmpty() &&
-                keyPasswordFromEnv != null && keyPasswordFromEnv.isNotEmpty()) {
-                storeFile = file(keystoreFileFromEnv)
-                storePassword = keystorePasswordFromEnv
-                keyAlias = keyAliasFromEnv
-                keyPassword = keyPasswordFromEnv
-            } else {
-                println("Warning: Release signing information not fully provided via environment variables. The release build might not be signed or might fail.")
-            }
-        }
-    }
-
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
此PR为项目带来自动化构建功能，包含两个Workflow：

- `main`分支的推送会触发自动debug构建，上传至artifact；

- 当新的tag提交时，会触发Release构建，并自动发布新的Release。最新Commit中Commit Message的正文部分(不包含Subject)会作为Release Notes。