### PR TITLE
chore: 更新工作流配置，添加权限设置并修复凭证持久化问题

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -10,10 +10,14 @@ jobs:
   build-debug-apk:
     name: Build Debug APK
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,20 @@ jobs:
   build-and-package:
     name: Build Release APK
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
@@ -37,7 +40,7 @@ jobs:
 
       - name: Sign APK
         id: sign-apk
-        uses: tiann/zipalign-sign-android-release@v1.1.4
+        uses: tiann/zipalign-sign-android-release@e76990551f7797c24236f9d39e72b3c49851ea3c # v1.1.4
         with:
           releaseDirectory: app/build/outputs/apk/release
           signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
@@ -64,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
           
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -85,8 +90,9 @@ jobs:
         
       - name: Extract Version from Tag
         id: extract_version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          TAG_NAME="${{ github.ref_name }}"
           VERSION_NUMBER=$(echo "$TAG_NAME" | sed 's/^v//')
           echo "version_number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION_NUMBER from tag: $TAG_NAME"


### PR DESCRIPTION
修复了以下的审计问题。
- artipacked 凭据持久化
	- 在两个 `actions/checkout@v4` 步骤中添加了 `persist-credentials: false`
- excessive-permissions 过度权限
	- 为 `build-and-package` 作业添加了 `permissions: contents: read` 限制权限
- template-injection 模板注入漏洞
	- 将 `TAG_NAME="${{ github.ref_name }}"` 改为使用环境变量安全传递
- unpinned-uses 未固定 Action 版本
	- 将 `tiann/zipalign-sign-android-release@v1.1.4` 固定到具体 commit hash
- cache-poisoning 缓存投毒风险
	- 移除了 JDK 设置中的 `cache: 'gradle'` 配置

审计工具 [zizmor](https://github.com/zizmorcore/zizmor)